### PR TITLE
ci: update GitHub Actions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -56,3 +56,8 @@ jobs:
       run: |
         .\build\test\test_main.exe
       shell: pwsh
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: build/src/fillgame_gui*


### PR DESCRIPTION
Closes #11 

It should create releases only when a tag is pushed.