### PR TITLE
Fixed DFPN best move selection (#74)

### DIFF
--- a/src/solver/dfpn.cpp
+++ b/src/solver/dfpn.cpp
@@ -89,9 +89,10 @@ void DFPN::MID(Node &node) {  // NOLINT
     delta = computeMinDelta(node);
   }
   // store search results
-  node.phi_   = delta;
-  node.delta_ = phi;
-  best_move_  = node.children_[best_child_index].move_;
+  node.phi_        = delta;
+  node.delta_      = phi;
+  best_child_index = selectChild(node, child_phi, delta_2);  // Need to recompute the best child. child_phi and delta_2 are unused after this anyways
+  best_move_       = node.children_[best_child_index].move_;
   /*
   if (best_child_index != UINT16_MAX) {
       best_move = node.children[best_child_index].move;

--- a/src/solver_main.cpp
+++ b/src/solver_main.cpp
@@ -40,6 +40,7 @@ void startSolver(std::string& input, size_t time_limit) {
   // constraint.apply();
   dfpn.solve();
   cout << dfpn.formatResult() << endl;
+  cout << "best move: " << dfpn.bestMove().toString() << endl;
 
   minimax::Minimax minimax(game);
   cout << "using minimax..." << endl;


### PR DESCRIPTION
Fixed best move selection for the DFPN algorithm.

In summary, we just needed to re-compute the best child after the `while` loop in MID.